### PR TITLE
Add another reinterpret_cast

### DIFF
--- a/window_main.h
+++ b/window_main.h
@@ -80,7 +80,7 @@ public:
 private:
 	void _init_setup_styles() noexcept {
 		this->setup.wndClassEx.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_BTNFACE + 1);
-		this->setup.wndClassEx.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+		this->setup.wndClassEx.hCursor = LoadCursorW(nullptr, reinterpret_cast<LPCWSTR>(IDC_ARROW));
 		this->setup.wndClassEx.style = CS_DBLCLKS;
 		this->setup.position = {CW_USEDEFAULT, CW_USEDEFAULT};
 		this->setup.size = {CW_USEDEFAULT, CW_USEDEFAULT};


### PR DESCRIPTION
Fixes error `window_main.h(83): error C2664: 'HCURSOR LoadCursorW(HINSTANCE,LPCWSTR)': cannot convert argument 2 from 'LPSTR' to 'LPCWSTR'`