### PR TITLE
Two new methods and a logic bug fix.

### DIFF
--- a/menu.h
+++ b/menu.h
@@ -36,6 +36,31 @@ public:
 		return *this;
 	}
 
+	menu& create() {
+		if (!this->_hMenu) {	
+			this->_hMenu = CreateMenu();
+			if (!this->_hMenu) {
+				throw std::system_error(GetLastError(), std::system_category(),
+					"CreateMenu failed");
+			}
+		}
+		else
+			throw std::logic_error("Trying to create a menu twice.");
+		return *this;
+	}
+
+	menu& show(HWND parent) {
+		if (!SetMenu(parent, this->_hMenu)){
+			throw std::system_error(GetLastError(), std::system_category(),
+				"SetMenu failed");
+		}
+		return *this;
+	}
+
+	menu& show(wl::wnd* parent) {
+		return show(parent->hwnd());
+	}
+	
 	void destroy() noexcept {
 		// Since HMENU resource can be shared, destroy() won't be called on destructor.
 		if (this->_hMenu) {


### PR DESCRIPTION
### **Additions**
New methods are simple - just a new `create(...)` interface and a `show` overloaded interface for the menu control to respectively create and draw the menu control.

-----
### **Fixes**
The bug was in the creation of a custom control, which for which the `HWND` returned from `CreateWindowExW` is never stored, causing all sorts of confusion (trying to figure out why computers hate me 🤣).

Also registering a class for a child control may be unintended here, as by doing so the caller loses the control type this instance is supposed to be based on.