### PR TITLE
Added `wl::download::on_data` callback

### DIFF
--- a/download.h
+++ b/download.h
@@ -267,15 +267,15 @@ private:
 
 		this->_totalGot += readCount; // update total downloaded count
 
+		// Call dataCallback with the bytes we just got
+		if (this->_dataCallback) {
+			this->_dataCallback(static_cast<BYTE*>(pWriteTo), readCount);
+		}
+
 		if (this->_stream != nullptr) {
 			this->_stream->write(static_cast<const char*>(pWriteTo), readCount); // write to stream
 		} else {
 			this->data.resize(beforeSize + readCount); // resize buffer to whatever was read
-		}
-
-		// Call dataCallback with the bytes we just got
-		if (this->_dataCallback) {
-			this->_dataCallback(static_cast<BYTE*>(pWriteTo), readCount);
 		}
 	}
 };

--- a/download.h
+++ b/download.h
@@ -275,7 +275,7 @@ private:
 
 		// Call dataCallback with the bytes we just got
 		if (this->_dataCallback) {
-			this->_dataCallback(static_cast<void*>(&this->data[beforeSize]), readCount);
+			this->_dataCallback(pWriteTo, readCount);
 		}
 	}
 };

--- a/download.h
+++ b/download.h
@@ -30,7 +30,7 @@ private:
 	insert_order_map<std::wstring, std::wstring> _requestHeaders;
 	insert_order_map<std::wstring, std::wstring> _responseHeaders;
 	std::function<void()> _startCallback, _progressCallback;
-	std::function<void(void*, DWORD)> _dataCallback;
+	std::function<void(BYTE*, DWORD)> _dataCallback;
 	std::ofstream* _stream = nullptr;
 
 public:
@@ -83,7 +83,7 @@ public:
 	}
 
 	// Defines a lambda do be called each time a chunk of bytes is received.
-	download& on_data(std::function<void(void*, DWORD)> callback) noexcept {
+	download& on_data(std::function<void(BYTE*, DWORD)> callback) noexcept {
 		this->_dataCallback = std::move(callback);
 		return *this;
 	}
@@ -275,7 +275,7 @@ private:
 
 		// Call dataCallback with the bytes we just got
 		if (this->_dataCallback) {
-			this->_dataCallback(pWriteTo, readCount);
+			this->_dataCallback((BYTE*)pWriteTo, readCount);
 		}
 	}
 };

--- a/download.h
+++ b/download.h
@@ -268,14 +268,14 @@ private:
 		this->_totalGot += readCount; // update total downloaded count
 
 		if (this->_stream != nullptr) {
-			this->_stream->write((const char*)pWriteTo, readCount); // write to stream
+			this->_stream->write(static_cast<const char*>(pWriteTo), readCount); // write to stream
 		} else {
 			this->data.resize(beforeSize + readCount); // resize buffer to whatever was read
 		}
 
 		// Call dataCallback with the bytes we just got
 		if (this->_dataCallback) {
-			this->_dataCallback((BYTE*)pWriteTo, readCount);
+			this->_dataCallback(static_cast<BYTE*>(pWriteTo), readCount);
 		}
 	}
 };

--- a/download.h
+++ b/download.h
@@ -28,6 +28,7 @@ private:
 	insert_order_map<std::wstring, std::wstring> _requestHeaders;
 	insert_order_map<std::wstring, std::wstring> _responseHeaders;
 	std::function<void()> _startCallback, _progressCallback;
+	std::function<void(void*, DWORD)> _dataCallback;
 
 public:
 	std::vector<BYTE> data;
@@ -71,6 +72,12 @@ public:
 	// Defines a lambda do be called each time a chunk of bytes is received.
 	download& on_progress(std::function<void()> callback) noexcept {
 		this->_progressCallback = std::move(callback);
+		return *this;
+	}
+
+	// Defines a lambda do be called each time a chunk of bytes is received.
+	download& on_data(std::function<void(void*, DWORD)> callback) noexcept {
+		this->_dataCallback = std::move(callback);
 		return *this;
 	}
 
@@ -232,6 +239,11 @@ private:
 
 		this->_totalGot += readCount; // update total downloaded count
 		this->data.resize(beforeSize + readCount); // resize buffer to whatever was read
+
+		// Call dataCallback with the bytes we just got
+		if (this->_dataCallback) {
+			this->_dataCallback(static_cast<void*>(&this->data[beforeSize]), readCount);
+		}
 	}
 };
 


### PR DESCRIPTION
This adds a callback that will be called when any data is received. Especially useful in combination with #27 (for eg. hashing downloads).

Changes rely on #25.

This will likely cause a merge conflict with #27, I'll fix that!