### PR TITLE
Added `wl::font::util::get_ui()`

### DIFF
--- a/font.h
+++ b/font.h
@@ -100,13 +100,7 @@ public:
 
 	// Create the same exact font used by UI, like Tahoma or Segoe UI.
 	font& create_ui() {
-		NONCLIENTMETRICS ncm{};
-		ncm.cbSize = sizeof(ncm);
-		if (!IsWindowsVistaOrGreater()) {
-			ncm.cbSize -= sizeof(ncm.iBorderWidth);
-		}
-		SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
-		return this->create(ncm.lfMenuFont); // Tahoma/Segoe
+		return this->create(util::get_ui());
 	}
 
 public:
@@ -148,6 +142,17 @@ public:
 				}, reinterpret_cast<LPARAM>(&isInstalled));
 			ReleaseDC(nullptr, hdc);
 			return isInstalled;
+		}
+
+		// Gets the LOGFONT options used by UI, like Tahoma or Segoe UI.
+		static LOGFONT get_ui() {
+			NONCLIENTMETRICS ncm{};
+			ncm.cbSize = sizeof(ncm);
+			if (!IsWindowsVistaOrGreater()) {
+				ncm.cbSize -= sizeof(ncm.iBorderWidth);
+			}
+			SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
+			return ncm.lfMenuFont;
 		}
 	};
 };


### PR DESCRIPTION
This moves the Tahoma/Segoe UI font querying from `create_ui` to a new static function. This makes it a bit easier to create fonts based on the system UI font. For example:

```cpp
auto fontConfig = wl::font::util::get_ui();
lstrcpyW(fontConfig.lfFaceName, L"MyFont");
someFont.create(fontConfig);
```