### PR TITLE
`wl::download` improvements

### DIFF
--- a/download.h
+++ b/download.h
@@ -7,6 +7,7 @@
 
 #pragma once
 #include <functional>
+#include <fstream>
 #include "internals/download_session.h"
 #include "internals/download_url.h"
 #include "insert_order_map.h"
@@ -23,11 +24,13 @@ public:
 private:
 	const session& _session;
 	HINTERNET      _hConnect = nullptr, _hRequest = nullptr;
+	DWORD          _statusCode = 0;
 	size_t         _contentLength = 0, _totalGot = 0;
 	std::wstring   _url, _verb, _referrer;
 	insert_order_map<std::wstring, std::wstring> _requestHeaders;
 	insert_order_map<std::wstring, std::wstring> _responseHeaders;
 	std::function<void()> _startCallback, _progressCallback;
+	std::ofstream* _stream = nullptr;
 
 public:
 	std::vector<BYTE> data;
@@ -49,6 +52,10 @@ public:
 			this->_hConnect = nullptr;
 		}
 		this->_contentLength = this->_totalGot = 0;
+		if (this->_stream != nullptr) {
+			delete this->_stream;
+			this->_stream = nullptr;
+		}
 		return *this;
 	}
 
@@ -74,6 +81,15 @@ public:
 		return *this;
 	}
 
+	// Set a file to write to instead of the data buffer.
+	download& to_file(const std::wstring& path) {
+		if (this->_stream != nullptr) {
+			throw std::logic_error("A file stream is already configured.");
+		}
+		this->_stream = new std::ofstream(path, std::wofstream::out | std::wofstream::binary);
+		return *this;
+	}
+
 	// Effectively starts the download, returning only after it completes.
 	download& start() {
 		if (this->_hConnect) {
@@ -82,6 +98,7 @@ public:
 			throw std::invalid_argument("Blank URL.");
 		}
 
+		this->_statusCode = 0;
 		this->_contentLength = this->_totalGot = 0;
 		this->_init_handles();
 		this->_contact_server();
@@ -108,6 +125,7 @@ public:
 
 	const insert_order_map<std::wstring, std::wstring>& get_request_headers() const noexcept  { return this->_requestHeaders; }
 	const insert_order_map<std::wstring, std::wstring>& get_response_headers() const noexcept { return this->_responseHeaders; }
+	DWORD get_status_code() const noexcept       { return this->_statusCode; }
 	size_t get_content_length() const noexcept   { return this->_contentLength; }
 	size_t get_total_downloaded() const noexcept { return this->_totalGot; }
 
@@ -172,6 +190,11 @@ private:
 	}
 
 	void _parse_headers() {
+		// Retrieve the status code.
+		DWORD dwSize = sizeof(DWORD);
+		WinHttpQueryHeaders(this->_hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+			WINHTTP_HEADER_NAME_BY_INDEX, &_statusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);
+
 		// Retrieve the response header.
 		DWORD rehSize = 0;
 		WinHttpQueryHeaders(this->_hRequest, WINHTTP_QUERY_RAW_HEADERS_CRLF,
@@ -219,17 +242,29 @@ private:
 	}
 
 	void _receive_bytes(UINT nBytesToRead) {
-		DWORD readCount = 0; // not used
-		this->data.resize(this->data.size() + nBytesToRead); // make room
+		void* pWriteTo = nullptr;
+		size_t beforeSize;
+		if (this->_stream != nullptr) {
+			this->data.resize(nBytesToRead); // make room
+			pWriteTo = static_cast<void*>(&this->data[0]);
+		} else {
+			beforeSize = this->data.size();
+			this->data.resize(beforeSize + nBytesToRead); // make room
+			pWriteTo = static_cast<void*>(&this->data[beforeSize]);
+		}
 
-		if (!WinHttpReadData(this->_hRequest,
-			static_cast<void*>(&this->data[this->data.size() - nBytesToRead]), // append to buffer
-			nBytesToRead, &readCount) )
-		{
+		DWORD readCount = 0;
+		if (!WinHttpReadData(this->_hRequest, pWriteTo, nBytesToRead, &readCount)) {
 			this->_abort_and_throw(GetLastError(), "WinHttpReadData failed");
 		}
 
-		this->_totalGot += nBytesToRead; // update total downloaded count
+		this->_totalGot += readCount; // update total downloaded count
+
+		if (this->_stream != nullptr) {
+			this->_stream->write((const char*)pWriteTo, readCount); // write to stream
+		} else {
+			this->data.resize(beforeSize + readCount); // resize buffer to whatever was read
+		}
 	}
 };
 

--- a/download.h
+++ b/download.h
@@ -267,15 +267,15 @@ private:
 
 		this->_totalGot += readCount; // update total downloaded count
 
+		// Call dataCallback with the bytes we just got
+		if (this->_dataCallback) {
+			this->_dataCallback(static_cast<BYTE*>(pWriteTo), readCount);
+		}
+
 		if (this->_stream != nullptr) {
 			this->_stream->write(static_cast<const char*>(pWriteTo), readCount); // write to stream
 		} else {
 			this->data.resize(beforeSize + readCount); // resize buffer to whatever was read
-		}
-
-		// Call dataCallback with the bytes we just got
-		if (this->_dataCallback) {
-			this->_dataCallback(static_cast<BYTE*>(pWriteTo), readCount);
 		}
 	}
 };

--- a/download.h
+++ b/download.h
@@ -275,7 +275,7 @@ private:
 
 		// Call dataCallback with the bytes we just got
 		if (this->_dataCallback) {
-			this->_dataCallback(static_cast<void*>(&this->data[beforeSize]), readCount);
+			this->_dataCallback(pWriteTo, readCount);
 		}
 	}
 };

--- a/download.h
+++ b/download.h
@@ -7,7 +7,6 @@
 
 #pragma once
 #include <functional>
-#include <fstream>
 #include "internals/download_session.h"
 #include "internals/download_url.h"
 #include "insert_order_map.h"

--- a/download.h
+++ b/download.h
@@ -30,7 +30,7 @@ private:
 	insert_order_map<std::wstring, std::wstring> _requestHeaders;
 	insert_order_map<std::wstring, std::wstring> _responseHeaders;
 	std::function<void()> _startCallback, _progressCallback;
-	std::function<void(void*, DWORD)> _dataCallback;
+	std::function<void(BYTE*, DWORD)> _dataCallback;
 	std::ofstream* _stream = nullptr;
 
 public:
@@ -83,7 +83,7 @@ public:
 	}
 
 	// Defines a lambda do be called each time a chunk of bytes is received.
-	download& on_data(std::function<void(void*, DWORD)> callback) noexcept {
+	download& on_data(std::function<void(BYTE*, DWORD)> callback) noexcept {
 		this->_dataCallback = std::move(callback);
 		return *this;
 	}
@@ -275,7 +275,7 @@ private:
 
 		// Call dataCallback with the bytes we just got
 		if (this->_dataCallback) {
-			this->_dataCallback(pWriteTo, readCount);
+			this->_dataCallback((BYTE*)pWriteTo, readCount);
 		}
 	}
 };

--- a/download.h
+++ b/download.h
@@ -268,14 +268,14 @@ private:
 		this->_totalGot += readCount; // update total downloaded count
 
 		if (this->_stream != nullptr) {
-			this->_stream->write((const char*)pWriteTo, readCount); // write to stream
+			this->_stream->write(static_cast<const char*>(pWriteTo), readCount); // write to stream
 		} else {
 			this->data.resize(beforeSize + readCount); // resize buffer to whatever was read
 		}
 
 		// Call dataCallback with the bytes we just got
 		if (this->_dataCallback) {
-			this->_dataCallback((BYTE*)pWriteTo, readCount);
+			this->_dataCallback(static_cast<BYTE*>(pWriteTo), readCount);
 		}
 	}
 };

--- a/download.h
+++ b/download.h
@@ -28,6 +28,7 @@ private:
 	insert_order_map<std::wstring, std::wstring> _requestHeaders;
 	insert_order_map<std::wstring, std::wstring> _responseHeaders;
 	std::function<void()> _startCallback, _progressCallback;
+	std::function<void(void*, DWORD)> _dataCallback;
 
 public:
 	std::vector<BYTE> data;
@@ -71,6 +72,12 @@ public:
 	// Defines a lambda do be called each time a chunk of bytes is received.
 	download& on_progress(std::function<void()> callback) noexcept {
 		this->_progressCallback = std::move(callback);
+		return *this;
+	}
+
+	// Defines a lambda do be called each time a chunk of bytes is received.
+	download& on_data(std::function<void(void*, DWORD)> callback) noexcept {
+		this->_dataCallback = std::move(callback);
 		return *this;
 	}
 
@@ -232,6 +239,11 @@ private:
 
 		this->_totalGot += readCount; // update total downloaded count
 		this->data.resize(beforeSize + readCount); // resize buffer to whatever was read
+
+		// Call dataCallback with the bytes we just got
+		if (this->_dataCallback) {
+			this->_dataCallback(static_cast<void*>(&this->data[beforeSize]), readCount);
+		}
 	}
 };
 

--- a/download.h
+++ b/download.h
@@ -12,6 +12,7 @@
 #include "internals/download_url.h"
 #include "insert_order_map.h"
 #include "str.h"
+#include "file.h"
 
 namespace wl {
 
@@ -31,7 +32,8 @@ private:
 	insert_order_map<std::wstring, std::wstring> _responseHeaders;
 	std::function<void()> _startCallback, _progressCallback;
 	std::function<void(BYTE*, DWORD)> _dataCallback;
-	std::ofstream* _stream = nullptr;
+	file _toFile;
+	std::vector<BYTE> _toFileBuffer;
 
 public:
 	std::vector<BYTE> data;
@@ -53,10 +55,6 @@ public:
 			this->_hConnect = nullptr;
 		}
 		this->_contentLength = this->_totalGot = 0;
-		if (this->_stream != nullptr) {
-			delete this->_stream;
-			this->_stream = nullptr;
-		}
 		return *this;
 	}
 
@@ -90,10 +88,10 @@ public:
 
 	// Set a file to write to instead of the data buffer.
 	download& to_file(const std::wstring& path) {
-		if (this->_stream != nullptr) {
+		if (this->_toFile.hfile()) {
 			throw std::logic_error("A file stream is already configured.");
 		}
-		this->_stream = new std::ofstream(path, std::wofstream::out | std::wofstream::binary);
+		this->_toFile.open_or_create(path);
 		return *this;
 	}
 
@@ -251,9 +249,9 @@ private:
 	void _receive_bytes(UINT nBytesToRead) {
 		void* pWriteTo = nullptr;
 		size_t beforeSize;
-		if (this->_stream != nullptr) {
-			this->data.resize(nBytesToRead); // make room
-			pWriteTo = static_cast<void*>(&this->data[0]);
+		if (this->_toFile.hfile()) {
+			this->_toFileBuffer.resize(nBytesToRead); // make room
+			pWriteTo = static_cast<void*>(&this->_toFileBuffer[0]);
 		} else {
 			beforeSize = this->data.size();
 			this->data.resize(beforeSize + nBytesToRead); // make room
@@ -272,8 +270,8 @@ private:
 			this->_dataCallback(static_cast<BYTE*>(pWriteTo), readCount);
 		}
 
-		if (this->_stream != nullptr) {
-			this->_stream->write(static_cast<const char*>(pWriteTo), readCount); // write to stream
+		if (this->_toFile.hfile()) {
+			this->_toFile.write(static_cast<const BYTE*>(pWriteTo), readCount); // write to stream
 		} else {
 			this->data.resize(beforeSize + readCount); // resize buffer to whatever was read
 		}

--- a/file.h
+++ b/file.h
@@ -382,7 +382,7 @@ public:
 		static std::vector<std::wstring> list_dir(const std::wstring& pathAndPattern) {
 			std::vector<std::wstring> files;
 
-			WIN32_FIND_DATA wfd{};
+			WIN32_FIND_DATAW wfd{};
 			HANDLE hFind = FindFirstFileW(pathAndPattern.c_str(), &wfd);
 			if (hFind == INVALID_HANDLE_VALUE) {
 				DWORD err = GetLastError();


### PR DESCRIPTION
Replaces #28.

Note that this also fixes a compilation error in `file.h`.

How would you prefer `to_file` to work? It feels like we could make it more flexible by passing in a preconfigured `wl::file` directly, although I'm unsure how that API would look.

It's also worth noting that `wl::file` does not currently support file truncation, so perhaps a later PR to add a `create()` method using `CREATE_ALWAYS` could be nice to have. But that's a different issue.